### PR TITLE
Strip whitespace

### DIFF
--- a/text_highlighter/__init__.py
+++ b/text_highlighter/__init__.py
@@ -52,6 +52,7 @@ def text_highlighter(
     key: Optional[str] = None,
     show_label_selector: bool = True,
     text_height: Optional[int] = None,
+    strip_whitespace: bool = False,
 ):
     """A text highlighter component.
 
@@ -71,6 +72,8 @@ def text_highlighter(
         Whether to show the label selector
     text_height : Optional[int]
         The height of the text area in pixels
+    strip_whitespace : bool
+        Whether to strip whitespace from any annotations
 
     Examples
     --------
@@ -107,6 +110,7 @@ def text_highlighter(
         selected_label=selected_label,
         show_label_selector=show_label_selector,
         text_height=text_height,
+        strip_whitespace=strip_whitespace,
     )
 
     class ComponentResult(list):  # type: ignore

--- a/text_highlighter/frontend/src/TextHighlighter.tsx
+++ b/text_highlighter/frontend/src/TextHighlighter.tsx
@@ -124,12 +124,12 @@ class MyComponent extends StreamlitComponentBase<BaseState> {
     return annotations;
   }
 
-  private updateState = (value: any, callback: any, strip: boolean): void => {
+  private updateState = (value: any, callback: any, strip_whitespace: boolean): void => {
     const text = this.props.args["text"];
     let trimmedValue = value;
 
     // Trim leading/trailing spaces by adjusting start/end indices
-    if (strip) {
+    if (strip_whitespace) {
         trimmedValue = value.map((annotation: any) => {
         let {start, end} = annotation;
 


### PR DESCRIPTION
# Feature

Adds an option to the component so that if a user highlights some text with leading or trailing whitespace, that whitespace can be automatically stripped.

We noticed a lot of our annotations were being saved with leading/trailing whitespace accidentally so want the option in this component to adjust that.

Currently we can post process the annotations but this allows it to happen in the UI as well.

# Changes
- Add python argument `strip_whitespace: bool = False` to the main component, preserving current behaviour
- Add typescript argument `strip_whitespace` to strip annotations after they have been selected in the UI and update the internal store of annotations to reflect that

# Testing
- Spun up local server and got desired behaviour with/without `strip_whitespace` turned on